### PR TITLE
Add workshop submission details and news article

### DIFF
--- a/content/news/2026-06-01/index.md
+++ b/content/news/2026-06-01/index.md
@@ -1,0 +1,42 @@
+---
+title: "Submissions open: HPC-ODA 2026 Workshop at SC26"
+date: 2026-06-01T00:00:00Z
+draft: false
+authors:
+  - michael-ott
+  - ayse-coskun
+  - jeff-hanson
+  - melissa-romanus
+  - woong-shin
+  - tim-osborne
+featured: true
+tags:
+  - Workshop
+  - SC26
+  - CFP
+---
+
+The submission system for paper and lightning talks submissions for the **1st International Workshop on HPC Operational Data Analytics (HPC-ODA 2026)** is now open.
+
+### Submission Types
+
+**Full papers** (8 two-column IEEE pages) and **short papers** (4 two-column IEEE pages) are invited on any aspect of operational data analytics in HPC. Topics of interest include ODA infrastructure, data collection pipelines, visualization and analytics, machine learning applications, data standardization and governance, energy and sustainability, digital twins, and HPC use cases and best practices.
+
+**Lightning talks** (5-minute presentations, 1-2 page extended abstract) provide an opportunity to share emerging work, operational experiences, and tools that may not be ready for a full paper submission. Lightning talk abstracts will not appear in the proceedings but will be documented in the workshop report.
+
+All submissions are peer-reviewed. Full and short papers will be published in the SC26 workshop proceedings in the IEEE Xplore Digital Library.
+
+### Important Dates
+
+- **July 31, 2026**, Full / Short Paper Submission Deadline
+- **September 18, 2026**, Lightning Talk Submission Deadline
+
+All deadlines are 11:59 PM AoE (Anywhere on Earth).
+
+### How to Submit
+
+Submissions are handled via the [SC Linklings submission system](https://submissions.supercomputing.org):
+* For **short and full papers** select *SC Workshop: HPC-ODA Lightning Talk*
+* For **lightning talksi** select *SC Workshop: HPC-ODA Lightning Talk*
+
+Full details are available on the [workshop page](/workshop2026/). We look forward to receiving your contributions.

--- a/content/workshop2026/_index.md
+++ b/content/workshop2026/_index.md
@@ -85,7 +85,7 @@ sections:
           - **Short papers** — 4 two-column pages, appropriate for work-in-progress or focused contributions  
           - **Full papers** — 8 two-column pages, for mature research contributions  
 
-        All papers must be submitted in PDF format using the [IEEE conference template](https://www.ieee.org/conferences/publishing/templates) via the SC Linklings submission system. Each submission will receive a minimum of three single-blind peer reviews.
+        All papers must be submitted in PDF format using the [IEEE conference template](https://www.ieee.org/conferences/publishing/templates) via the [SC Linklings submission system](https://submissions.supercomputing.org) (select *SC Workshop: HPC-ODA*). Each submission will receive a minimum of three single-blind peer reviews.
 
         In support of the [SC26 Reproducibility Initiative](https://sc26.supercomputing.org/program/papers/reproducibility-initiative/), authors may optionally submit an Artifact Description and Artifact Evaluation (AD/AE) appendix. This appendix will not be reviewed but will be included with papers after acceptance, in accordance with SC26 guidelines.
 
@@ -95,7 +95,7 @@ sections:
 
         Lightning talks provide an opportunity to present emerging work, operational experiences, tools, dashboards, and other contributions that may not be suitable for full or short paper submissions. Submissions are welcome from across the HPC community, including researchers, practitioners, and students. We especially encourage contributions that share early-stage ideas, operational insights, or practical experiences.
 
-        Lightning talk submissions should consist of an extended abstract (1–2 pages). There is no strict formatting requirement; however, submissions should be clear, well-structured, and comparable in scope to a short paper (e.g., including motivation, approach, and key outcomes). Submissions should be provided as a PDF.
+        Lightning talk submissions should consist of an extended abstract (1–2 pages) in PDF format and must be submitted via the [SC Linklings submission system](https://submissions.supercomputing.org) (select *SC Workshop: HPC-ODA Lightning Talk*). There is no strict formatting requirement; however, submissions should be clear, well-structured, and comparable in scope to a short paper (e.g., including motivation, approach, and key outcomes). Submissions should be provided as a PDF.
 
         Submissions will be peer-reviewed for relevance and quality. Accepted lightning talks will be allocated a 5-minute presentation slot and will be documented in the HPC-ODA workshop report published through the EE HPC WG.
 


### PR DESCRIPTION
Adding links to SC Linklings. Unfortunately there's no direct link to our workshop, so I've added instructions on which submission has to be used.